### PR TITLE
Added X-Plex-Token for authentication

### DIFF
--- a/conf/plex_tvst_scrobbler.conf
+++ b/conf/plex_tvst_scrobbler.conf
@@ -16,3 +16,7 @@ session = /tmp/plex_tvst_scrobbler_session_key
 # a Linux system. You may wish to change this value to reference your OS install.
 # https://support.plex.tv/hc/en-us/articles/200250417-Plex-Media-Server-Log-Files
 #mediaserver_log_location = /path/to/plex/media/server/log
+
+# OPTIONAL: required only when using authentication even in local networks
+# See how to get your token @ https://support.plex.tv/hc/en-us/articles/204059436-Finding-your-account-token-X-Plex-Token
+#plex_token=PTcNmIrOg2ZmB1GpLCNn

--- a/plex_tvst_scrobbler/plex_monitor.py
+++ b/plex_tvst_scrobbler/plex_monitor.py
@@ -35,8 +35,8 @@ def fetch_metadata(l_id, config):
     ''' retrieves the metadata information from the Plex media Server api. '''
 
     logger = logging.getLogger(__name__)
-    url = '{url}/library/metadata/{l_id}'.format(url=config.get('plex-tvst-scrobbler',
-      'mediaserver_url'), l_id=l_id)
+    url = '{url}/library/metadata/{l_id}?X-Plex-Token={plex_token}'.format(url=config.get('plex-tvst-scrobbler',
+      'mediaserver_url'), l_id=l_id, plex_token=config.get('plex-tvst-scrobbler','plex_token'))
     logger.info('Fetching library metadata from {url}'.format(url=url))
 
     # fail if request is greater than 2 seconds.


### PR DESCRIPTION
Hi,

This is a fix for the scrobbler not working when X-Plex-Token is required in order to use the API when using plex home.

Let me know if you have any questions.
